### PR TITLE
Fix HTML special chars in tweets text

### DIFF
--- a/tweets.module
+++ b/tweets.module
@@ -24,7 +24,7 @@ function template_preprocess_tweets(&$variables) {
 
       $settings = array(
         '#type' => 'processed_text',
-        '#text' => $tweet->text,
+        '#text' => htmlspecialchars_decode($tweet->text),
         '#format' => NULL,
         '#filter_types_to_skip' => array(),
         '#langcode' => '',


### PR DESCRIPTION
Tweets block isn't decoding HTML special chars like `&amp;` or `&quot;`
Ref. http://php.net/manual/en/function.htmlspecialchars-decode.php